### PR TITLE
Support for Perl 5.24 and year 2016; removed POD comment

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Modern::Perl
 
 {{$NEXT}}
+    - updated for 2016 release (Gryphon Shafer)
+    - added support for 5.24
 
 1.20150127 2015-01-26 23:21:44-08:00 America/Los_Angeles
     - updated for 2015 release (Elmer Quintanilla)

--- a/README
+++ b/README
@@ -40,7 +40,7 @@ You can also look for information at:
 
 COPYRIGHT AND LICENCE
 
-Copyright (C) 2009-2015 chromatic
+Copyright (C) 2009-2016 chromatic
 
 This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name             = Modern-Perl
 author           = chromatic
 license          = Perl_5
 copyright_holder = chromatic@wgz.org
-copyright_year   = 2015
+copyright_year   = 2016
 
 [AutoVersion]
 format = {{ cldr('1.yyyyMMdd') }}

--- a/lib/Modern/Perl.pm
+++ b/lib/Modern/Perl.pm
@@ -24,7 +24,7 @@ sub VERSION
     return $VERSION if             $version < 2009;
 
     $wanted_date = $version if (caller(1))[3] =~ /::BEGIN/;
-    return 2014;
+    return 2016;
 }
 
 sub import
@@ -57,6 +57,7 @@ my %dates =
     2013 => ':5.16',
     2014 => ':5.18',
     2015 => ':5.20',
+    2016 => ':5.24',
 );
 
 sub validate_date
@@ -131,14 +132,14 @@ optional import tag. For example:
 
     use Modern::Perl '2015';
 
-... enables 5.20 features.
+... enables 5.20 features, and:
+
+    use Modern::Perl '2016';
+
+... enables 5.24 features.
 
 Obviously you cannot use newer features on earlier
 versions. Perl will throw the appropriate exception if you try.
-
-By mid-2014, this module will drop support for 5.10 and 5.12 and will complain
-(once per process) if you use a year too old. As of January 2014, Perl 5.14 is
-unsupported by the Perl 5 Porters, so please consider upgrading.
 
 =head1 AUTHOR
 
@@ -193,7 +194,7 @@ features.
 
 =head1 COPYRIGHT & LICENSE
 
-Copyright 2009-2014 chromatic, all rights reserved.
+Copyright 2009-2016 chromatic, all rights reserved.
 
 This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl 5.18 itself.

--- a/t/year_imports.t
+++ b/t/year_imports.t
@@ -157,6 +157,34 @@ if ($] >= 5.020)
     is $@, '', 'this block should succeed';
 }
 
+if ($] >= 5.024)
+{
+    eval q{
+        use Modern::Perl '2016';
+        eval 'sub { given (0) {} }';
+        is $@, '', q|use Modern::Perl '2016' enables switch|;
+        eval 'sub { say 0 }';
+        is $@, '', q|use Modern::Perl '2016' enables say|;
+        eval 'state $x';
+        is $@, '', q|use Modern::Perl '2016' enables state|;
+        is uc "\xdf", "SS", '2016 enables unicode_strings';
+        eval 'sub { return __SUB__ }';
+        is $@, '', q|use Modern::Perl '2016' enables current_sub|;
+        my $warning = '';
+        local $SIG{__WARN__} = sub { $warning = shift };
+        eval '$[ = 10';
+        like $warning, qr/Use of assignment to \$\[ is deprecated/,
+            q|use Modern::Perl '2016' disables array_base|;
+        eval 'fc("tschü¼Ã")eq fc("TSCHÃS")';
+        is $@, '', q|use Modern::Perl '2016' enables fc|;
+        eval 'my $r = [ 1, [ 2, 3 ], 4 ]; $r->[1]->@*';
+        is $@, '', q|use Modern::Perl '2016' enables postderef_qq|;
+        eval 'my sub foo {}';
+        isnt $@, '', q|use Modern::Perl '2016' does not enable lexical subs|;
+    };
+    is $@, '', 'this block should succeed';
+}
+
 eval 'sub { given (0) {} }';
 isnt $@, "", 'switch feature does not leak out';
 eval 'sub { say 0 }';


### PR DESCRIPTION
- Added support for Perl 5.24 and year 2016. Updated tests to cover that.
- Updated copyright year to 2016 (because I have CDO).
- Removed seemingly outdated POD comment about dropping support for 5.10 and 5.12 in mid-2014, since it's toward the end of 2016 now (and also because I have CDO).
