### PR TITLE
Fix issue #5 of missing $Modern::Perl::VERSION

### DIFF
--- a/lib/Modern/Perl.pm
+++ b/lib/Modern/Perl.pm
@@ -13,15 +13,13 @@ use feature ();
 use IO::File   ();
 use IO::Handle ();
 
-our $VERSION;
-
 my $wanted_date;
 sub VERSION
 {
     my ($self, $version) = @_;
 
-    return $VERSION unless defined $version;
-    return $VERSION if             $version < 2009;
+    return $Modern::Perl::VERSION || 2016 unless defined $version;
+    return $Modern::Perl::VERSION || 2016 if             $version < 2009;
 
     $wanted_date = $version if (caller(1))[3] =~ /::BEGIN/;
     return 2016;


### PR DESCRIPTION
This will in theory fix issue #5 that results in a missing $Modern::Perl::VERSION on dzil builds that get published to CPAN. I think I've patch this such that both the pre-dzil-ed and post-dzil-ed version will pass all their tests.
