### PR TITLE
Removed left-over autodie dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,7 +11,6 @@ format = {{ cldr('1.yyyyMMdd') }}
 
 [Prereqs]
 perl    = 5.010
-autodie = 2.22
 
 [@Filter]
 -bundle = @Basic


### PR DESCRIPTION
Removed the entry for the autodie dependency. Credit to mst and others in the Freenode #perl channel.